### PR TITLE
Milestone logic of correct weapons values and attack for both player and enemies

### DIFF
--- a/Assets/EnemyMappings/Ant-Blue.asset
+++ b/Assets/EnemyMappings/Ant-Blue.asset
@@ -13,8 +13,8 @@ MonoBehaviour:
   m_Name: Ant-Blue
   m_EditorClassIdentifier: 
   enemyName: Ant-Blue
-  baseWarHP: 4
-  baseSpiritualHP: 2
+  baseWarHP: 2
+  baseSpiritualHP: 4
   baseAttack: 3
   baseDefense: 1
   colorMultiplier: 1

--- a/Assets/ItemsMappings/Bow-Blue.asset
+++ b/Assets/ItemsMappings/Bow-Blue.asset
@@ -17,10 +17,18 @@ MonoBehaviour:
   item2DSprite: {fileID: 2800000, guid: 14fe27848ae6e470d8f7d40b68507f4f, type: 3}
   ammo: {fileID: 7597464235342884792, guid: 7aabb6e00b7e84371bbaf5c73f33df78, type: 3}
   isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
   isShield: 0
   isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
   isWarWeapon: 1
   isSpiritualWeapon: 0
+  isMultiUseWeapon: 1
   isHelmet: 0
   isBreastPlate: 0
   isGauntlet: 0
@@ -28,6 +36,7 @@ MonoBehaviour:
   isRing: 0
   isPotion: 0
   isKey: 0
+  isBomb: 0
   warAttackPower: 15
   spiritualAttackPower: 0
   warDefense: 0

--- a/Assets/ItemsMappings/Bow-Grey.asset
+++ b/Assets/ItemsMappings/Bow-Grey.asset
@@ -17,10 +17,18 @@ MonoBehaviour:
   item2DSprite: {fileID: 2800000, guid: 4cb8f65a7ebbb4b379b6543a89523c43, type: 3}
   ammo: {fileID: 7746456183533234253, guid: 1778bedaba4e744808acec99e07b0c43, type: 3}
   isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
   isShield: 0
   isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
   isWarWeapon: 1
   isSpiritualWeapon: 0
+  isMultiUseWeapon: 1
   isHelmet: 0
   isBreastPlate: 0
   isGauntlet: 0
@@ -28,6 +36,7 @@ MonoBehaviour:
   isRing: 0
   isPotion: 0
   isKey: 0
+  isBomb: 0
   warAttackPower: 21
   spiritualAttackPower: 0
   warDefense: 0

--- a/Assets/ItemsMappings/Bow-Orange.asset
+++ b/Assets/ItemsMappings/Bow-Orange.asset
@@ -17,10 +17,18 @@ MonoBehaviour:
   item2DSprite: {fileID: 2800000, guid: af5e81dfa78334840b8d42e0ff0c564b, type: 3}
   ammo: {fileID: 3742031186087403012, guid: 4f4948675bc38405d8713819b51e12f2, type: 3}
   isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
   isShield: 0
   isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
   isWarWeapon: 1
   isSpiritualWeapon: 0
+  isMultiUseWeapon: 1
   isHelmet: 0
   isBreastPlate: 0
   isGauntlet: 0
@@ -28,6 +36,7 @@ MonoBehaviour:
   isRing: 0
   isPotion: 0
   isKey: 0
+  isBomb: 0
   warAttackPower: 9
   spiritualAttackPower: 0
   warDefense: 0

--- a/Assets/ItemsMappings/Bow-Tan.asset
+++ b/Assets/ItemsMappings/Bow-Tan.asset
@@ -17,10 +17,18 @@ MonoBehaviour:
   item2DSprite: {fileID: 2800000, guid: ce868cab0f6ce4c30a0b410c75b6888e, type: 3}
   ammo: {fileID: 1103623130113142968, guid: 33555d5796fec4b2286265aae4c3005d, type: 3}
   isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
   isShield: 0
   isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
   isWarWeapon: 1
   isSpiritualWeapon: 0
+  isMultiUseWeapon: 1
   isHelmet: 0
   isBreastPlate: 0
   isGauntlet: 0
@@ -28,6 +36,7 @@ MonoBehaviour:
   isRing: 0
   isPotion: 0
   isKey: 0
+  isBomb: 0
   warAttackPower: 6
   spiritualAttackPower: 0
   warDefense: 0

--- a/Assets/ItemsMappings/Bow-White.asset
+++ b/Assets/ItemsMappings/Bow-White.asset
@@ -17,10 +17,18 @@ MonoBehaviour:
   item2DSprite: {fileID: 2800000, guid: aab4ee3cd10d74042911e8aa539edaf5, type: 3}
   ammo: {fileID: 6074387981640591998, guid: 5167b2aff4f95480d81c558dc1bab03b, type: 3}
   isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
   isShield: 0
   isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
   isWarWeapon: 1
   isSpiritualWeapon: 0
+  isMultiUseWeapon: 1
   isHelmet: 0
   isBreastPlate: 0
   isGauntlet: 0
@@ -28,6 +36,7 @@ MonoBehaviour:
   isRing: 0
   isPotion: 0
   isKey: 0
+  isBomb: 0
   warAttackPower: 33
   spiritualAttackPower: 0
   warDefense: 0

--- a/Assets/ItemsMappings/Bow-Yellow.asset
+++ b/Assets/ItemsMappings/Bow-Yellow.asset
@@ -17,10 +17,18 @@ MonoBehaviour:
   item2DSprite: {fileID: 2800000, guid: c25bccdbb111f46aa928df9b9e09b54d, type: 3}
   ammo: {fileID: 6756616008823049172, guid: e4801310767034094a03772ac1203cb7, type: 3}
   isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
   isShield: 0
   isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
   isWarWeapon: 1
   isSpiritualWeapon: 0
+  isMultiUseWeapon: 1
   isHelmet: 0
   isBreastPlate: 0
   isGauntlet: 0
@@ -28,6 +36,7 @@ MonoBehaviour:
   isRing: 0
   isPotion: 0
   isKey: 0
+  isBomb: 0
   warAttackPower: 27
   spiritualAttackPower: 0
   warDefense: 0

--- a/Assets/ItemsMappings/Crossbow-Blue.asset
+++ b/Assets/ItemsMappings/Crossbow-Blue.asset
@@ -17,10 +17,18 @@ MonoBehaviour:
   item2DSprite: {fileID: 2800000, guid: a49d0a5d2287a422799b535e1b347908, type: 3}
   ammo: {fileID: 7597464235342884792, guid: 7aabb6e00b7e84371bbaf5c73f33df78, type: 3}
   isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
   isShield: 0
   isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
   isWarWeapon: 1
   isSpiritualWeapon: 0
+  isMultiUseWeapon: 1
   isHelmet: 0
   isBreastPlate: 0
   isGauntlet: 0
@@ -28,6 +36,7 @@ MonoBehaviour:
   isRing: 0
   isPotion: 0
   isKey: 0
+  isBomb: 0
   warAttackPower: 30
   spiritualAttackPower: 0
   warDefense: 0

--- a/Assets/ItemsMappings/Crossbow-Grey.asset
+++ b/Assets/ItemsMappings/Crossbow-Grey.asset
@@ -17,10 +17,18 @@ MonoBehaviour:
   item2DSprite: {fileID: 2800000, guid: 821cbf4da97624f7bbbc2a688f959895, type: 3}
   ammo: {fileID: 7746456183533234253, guid: 1778bedaba4e744808acec99e07b0c43, type: 3}
   isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
   isShield: 0
   isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
   isWarWeapon: 1
   isSpiritualWeapon: 0
+  isMultiUseWeapon: 1
   isHelmet: 0
   isBreastPlate: 0
   isGauntlet: 0
@@ -28,6 +36,7 @@ MonoBehaviour:
   isRing: 0
   isPotion: 0
   isKey: 0
+  isBomb: 0
   warAttackPower: 36
   spiritualAttackPower: 0
   warDefense: 0

--- a/Assets/ItemsMappings/Crossbow-Orange.asset
+++ b/Assets/ItemsMappings/Crossbow-Orange.asset
@@ -17,10 +17,18 @@ MonoBehaviour:
   item2DSprite: {fileID: 2800000, guid: 43159d71fad4c4e46a1d82594ba539c8, type: 3}
   ammo: {fileID: 3742031186087403012, guid: 4f4948675bc38405d8713819b51e12f2, type: 3}
   isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
   isShield: 0
   isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
   isWarWeapon: 1
   isSpiritualWeapon: 0
+  isMultiUseWeapon: 1
   isHelmet: 0
   isBreastPlate: 0
   isGauntlet: 0
@@ -28,6 +36,7 @@ MonoBehaviour:
   isRing: 0
   isPotion: 0
   isKey: 0
+  isBomb: 0
   warAttackPower: 24
   spiritualAttackPower: 0
   warDefense: 0

--- a/Assets/ItemsMappings/Crossbow-Tan.asset
+++ b/Assets/ItemsMappings/Crossbow-Tan.asset
@@ -17,10 +17,18 @@ MonoBehaviour:
   item2DSprite: {fileID: 2800000, guid: 8ac22766f3052447ba3aa0e6eefb85dd, type: 3}
   ammo: {fileID: 1103623130113142968, guid: 33555d5796fec4b2286265aae4c3005d, type: 3}
   isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
   isShield: 0
   isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
   isWarWeapon: 1
   isSpiritualWeapon: 0
+  isMultiUseWeapon: 1
   isHelmet: 0
   isBreastPlate: 0
   isGauntlet: 0
@@ -28,6 +36,7 @@ MonoBehaviour:
   isRing: 0
   isPotion: 0
   isKey: 0
+  isBomb: 0
   warAttackPower: 18
   spiritualAttackPower: 0
   warDefense: 0

--- a/Assets/ItemsMappings/Crossbow-White.asset
+++ b/Assets/ItemsMappings/Crossbow-White.asset
@@ -17,10 +17,18 @@ MonoBehaviour:
   item2DSprite: {fileID: 2800000, guid: 866b70dc5d16e440c87cce1b48281688, type: 3}
   ammo: {fileID: 6074387981640591998, guid: 5167b2aff4f95480d81c558dc1bab03b, type: 3}
   isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
   isShield: 0
   isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
   isWarWeapon: 1
   isSpiritualWeapon: 0
+  isMultiUseWeapon: 1
   isHelmet: 0
   isBreastPlate: 0
   isGauntlet: 0
@@ -28,6 +36,7 @@ MonoBehaviour:
   isRing: 0
   isPotion: 0
   isKey: 0
+  isBomb: 0
   warAttackPower: 99
   spiritualAttackPower: 0
   warDefense: 0

--- a/Assets/ItemsMappings/Crossbow-Yellow.asset
+++ b/Assets/ItemsMappings/Crossbow-Yellow.asset
@@ -17,10 +17,18 @@ MonoBehaviour:
   item2DSprite: {fileID: 2800000, guid: b026c6fd476594f3ba496a9ba5efd4be, type: 3}
   ammo: {fileID: 6756616008823049172, guid: e4801310767034094a03772ac1203cb7, type: 3}
   isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
   isShield: 0
   isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
   isWarWeapon: 1
   isSpiritualWeapon: 0
+  isMultiUseWeapon: 1
   isHelmet: 0
   isBreastPlate: 0
   isGauntlet: 0
@@ -28,6 +36,7 @@ MonoBehaviour:
   isRing: 0
   isPotion: 0
   isKey: 0
+  isBomb: 0
   warAttackPower: 42
   spiritualAttackPower: 0
   warDefense: 0

--- a/Assets/ItemsMappings/Scroll-Blue.asset
+++ b/Assets/ItemsMappings/Scroll-Blue.asset
@@ -17,10 +17,18 @@ MonoBehaviour:
   item2DSprite: {fileID: 2800000, guid: 1e4fc5ed7b7ae4c29acbb8e75fe156d9, type: 3}
   ammo: {fileID: 786704032597579913, guid: e6c43b1340941430584f9ba0b1742671, type: 3}
   isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
   isShield: 0
   isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
   isWarWeapon: 0
   isSpiritualWeapon: 1
+  isMultiUseWeapon: 1
   isHelmet: 0
   isBreastPlate: 0
   isGauntlet: 0
@@ -28,6 +36,7 @@ MonoBehaviour:
   isRing: 0
   isPotion: 0
   isKey: 0
+  isBomb: 0
   warAttackPower: 0
   spiritualAttackPower: 3
   warDefense: 0

--- a/Assets/ItemsMappings/Scroll-Grey.asset
+++ b/Assets/ItemsMappings/Scroll-Grey.asset
@@ -17,10 +17,18 @@ MonoBehaviour:
   item2DSprite: {fileID: 2800000, guid: 76e970cf4b5044c2ebcb492e7c74423a, type: 3}
   ammo: {fileID: 7765118638121681247, guid: d95db25e8315d458e971d610f6190af7, type: 3}
   isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
   isShield: 0
   isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
   isWarWeapon: 0
   isSpiritualWeapon: 1
+  isMultiUseWeapon: 1
   isHelmet: 0
   isBreastPlate: 0
   isGauntlet: 0
@@ -28,6 +36,7 @@ MonoBehaviour:
   isRing: 0
   isPotion: 0
   isKey: 0
+  isBomb: 0
   warAttackPower: 0
   spiritualAttackPower: 5
   warDefense: 0

--- a/Assets/ItemsMappings/Scroll-Pink.asset
+++ b/Assets/ItemsMappings/Scroll-Pink.asset
@@ -17,10 +17,18 @@ MonoBehaviour:
   item2DSprite: {fileID: 2800000, guid: 9b015f0fa408b43e5bc43576de0d12cc, type: 3}
   ammo: {fileID: 6233843619771494365, guid: b4c3eca7d545a4c70b39eb0e659cbea2, type: 3}
   isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
   isShield: 0
   isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
   isWarWeapon: 0
   isSpiritualWeapon: 1
+  isMultiUseWeapon: 1
   isHelmet: 0
   isBreastPlate: 0
   isGauntlet: 0
@@ -28,6 +36,7 @@ MonoBehaviour:
   isRing: 0
   isPotion: 0
   isKey: 0
+  isBomb: 0
   warAttackPower: 0
   spiritualAttackPower: 13
   warDefense: 0

--- a/Assets/ItemsMappings/Scroll-Purple.asset
+++ b/Assets/ItemsMappings/Scroll-Purple.asset
@@ -17,10 +17,18 @@ MonoBehaviour:
   item2DSprite: {fileID: 2800000, guid: 617544b71a8914ce3b397af81c7492f6, type: 3}
   ammo: {fileID: 3977643026662185120, guid: 73ead4fc7dbb0467d8c719786d6da76b, type: 3}
   isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
   isShield: 0
   isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
   isWarWeapon: 0
   isSpiritualWeapon: 1
+  isMultiUseWeapon: 1
   isHelmet: 0
   isBreastPlate: 0
   isGauntlet: 0
@@ -28,6 +36,7 @@ MonoBehaviour:
   isRing: 0
   isPotion: 0
   isKey: 0
+  isBomb: 0
   warAttackPower: 0
   spiritualAttackPower: 21
   warDefense: 0

--- a/Assets/ItemsMappings/Scroll-Red.asset
+++ b/Assets/ItemsMappings/Scroll-Red.asset
@@ -17,10 +17,18 @@ MonoBehaviour:
   item2DSprite: {fileID: 2800000, guid: d4dbe0c8dff774f01a637ddb1da24aae, type: 3}
   ammo: {fileID: 2540364331377957749, guid: 86380ea49bae1473a8349d95c452c312, type: 3}
   isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
   isShield: 0
   isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
   isWarWeapon: 0
   isSpiritualWeapon: 1
+  isMultiUseWeapon: 1
   isHelmet: 0
   isBreastPlate: 0
   isGauntlet: 0
@@ -28,6 +36,7 @@ MonoBehaviour:
   isRing: 0
   isPotion: 0
   isKey: 0
+  isBomb: 0
   warAttackPower: 0
   spiritualAttackPower: 17
   warDefense: 0

--- a/Assets/ItemsMappings/Scroll-White.asset
+++ b/Assets/ItemsMappings/Scroll-White.asset
@@ -17,10 +17,18 @@ MonoBehaviour:
   item2DSprite: {fileID: 2800000, guid: 0b8274973a3594b50b86d97335fdb519, type: 3}
   ammo: {fileID: 3867954087016002046, guid: 6fd7b1a5bd5ce4f0bb1b22432560c94c, type: 3}
   isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
   isShield: 0
   isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
   isWarWeapon: 0
   isSpiritualWeapon: 1
+  isMultiUseWeapon: 1
   isHelmet: 0
   isBreastPlate: 0
   isGauntlet: 0
@@ -28,6 +36,7 @@ MonoBehaviour:
   isRing: 0
   isPotion: 0
   isKey: 0
+  isBomb: 0
   warAttackPower: 0
   spiritualAttackPower: 9
   warDefense: 0

--- a/Assets/ItemsMappings/Spell-Book-Blue.asset
+++ b/Assets/ItemsMappings/Spell-Book-Blue.asset
@@ -16,6 +16,27 @@ MonoBehaviour:
   item3DPrefab: {fileID: 778963475273438515, guid: 7e8dead22474a4cc789e38f36fca74f3, type: 3}
   item2DSprite: {fileID: 2800000, guid: 96edcc2ad98a343b9a98821996565718, type: 3}
   ammo: {fileID: 786704032597579913, guid: e6c43b1340941430584f9ba0b1742671, type: 3}
+  isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
+  isShield: 0
+  isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
+  isWarWeapon: 0
+  isSpiritualWeapon: 1
+  isMultiUseWeapon: 1
+  isHelmet: 0
+  isBreastPlate: 0
+  isGauntlet: 0
+  isHauberk: 0
+  isRing: 0
+  isPotion: 0
+  isKey: 0
+  isBomb: 0
   warAttackPower: 0
   spiritualAttackPower: 11
   warDefense: 0

--- a/Assets/ItemsMappings/Spell-Book-Grey.asset
+++ b/Assets/ItemsMappings/Spell-Book-Grey.asset
@@ -16,6 +16,27 @@ MonoBehaviour:
   item3DPrefab: {fileID: 5781688211830426638, guid: c5d029cf027a74c65abc1dc36a30b159, type: 3}
   item2DSprite: {fileID: 2800000, guid: b1e16a37ec6e9431a83d1adafccb0133, type: 3}
   ammo: {fileID: 7765118638121681247, guid: d95db25e8315d458e971d610f6190af7, type: 3}
+  isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
+  isShield: 0
+  isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
+  isWarWeapon: 0
+  isSpiritualWeapon: 1
+  isMultiUseWeapon: 1
+  isHelmet: 0
+  isBreastPlate: 0
+  isGauntlet: 0
+  isHauberk: 0
+  isRing: 0
+  isPotion: 0
+  isKey: 0
+  isBomb: 0
   warAttackPower: 0
   spiritualAttackPower: 15
   warDefense: 0

--- a/Assets/ItemsMappings/Spell-Book-Pink.asset
+++ b/Assets/ItemsMappings/Spell-Book-Pink.asset
@@ -16,6 +16,27 @@ MonoBehaviour:
   item3DPrefab: {fileID: 1750110910666076061, guid: 74397cdfe93f0415a8db76870d5eab02, type: 3}
   item2DSprite: {fileID: 2800000, guid: 80b19d585ac9e434ca3d104ddebe5577, type: 3}
   ammo: {fileID: 6233843619771494365, guid: b4c3eca7d545a4c70b39eb0e659cbea2, type: 3}
+  isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
+  isShield: 0
+  isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
+  isWarWeapon: 0
+  isSpiritualWeapon: 1
+  isMultiUseWeapon: 1
+  isHelmet: 0
+  isBreastPlate: 0
+  isGauntlet: 0
+  isHauberk: 0
+  isRing: 0
+  isPotion: 0
+  isKey: 0
+  isBomb: 0
   warAttackPower: 0
   spiritualAttackPower: 23
   warDefense: 0

--- a/Assets/ItemsMappings/Spell-Book-Purple.asset
+++ b/Assets/ItemsMappings/Spell-Book-Purple.asset
@@ -16,6 +16,27 @@ MonoBehaviour:
   item3DPrefab: {fileID: 1096498210097460157, guid: a89d8d2b1639841d880f4158c2a0f954, type: 3}
   item2DSprite: {fileID: 2800000, guid: c45bb87d58bb24ae68ffa7c514fb7144, type: 3}
   ammo: {fileID: 3977643026662185120, guid: 73ead4fc7dbb0467d8c719786d6da76b, type: 3}
+  isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
+  isShield: 0
+  isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
+  isWarWeapon: 0
+  isSpiritualWeapon: 1
+  isMultiUseWeapon: 1
+  isHelmet: 0
+  isBreastPlate: 0
+  isGauntlet: 0
+  isHauberk: 0
+  isRing: 0
+  isPotion: 0
+  isKey: 0
+  isBomb: 0
   warAttackPower: 0
   spiritualAttackPower: 65
   warDefense: 0

--- a/Assets/ItemsMappings/Spell-Book-Red.asset
+++ b/Assets/ItemsMappings/Spell-Book-Red.asset
@@ -16,6 +16,27 @@ MonoBehaviour:
   item3DPrefab: {fileID: 1284919927926129152, guid: 1011c8dc0bf03490cbdec567b1030bdf, type: 3}
   item2DSprite: {fileID: 2800000, guid: 53b9738b0e8e74508b8d902a56b6f203, type: 3}
   ammo: {fileID: 2540364331377957749, guid: 86380ea49bae1473a8349d95c452c312, type: 3}
+  isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
+  isShield: 0
+  isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
+  isWarWeapon: 0
+  isSpiritualWeapon: 1
+  isMultiUseWeapon: 1
+  isHelmet: 0
+  isBreastPlate: 0
+  isGauntlet: 0
+  isHauberk: 0
+  isRing: 0
+  isPotion: 0
+  isKey: 0
+  isBomb: 0
   warAttackPower: 0
   spiritualAttackPower: 27
   warDefense: 0

--- a/Assets/ItemsMappings/Spell-Book-White.asset
+++ b/Assets/ItemsMappings/Spell-Book-White.asset
@@ -16,6 +16,27 @@ MonoBehaviour:
   item3DPrefab: {fileID: 8610500748915350336, guid: f260f54b560904d878bc9977ac453f53, type: 3}
   item2DSprite: {fileID: 2800000, guid: 5097c69ae9f774aa8a3b94aee9a871c9, type: 3}
   ammo: {fileID: 3867954087016002046, guid: 6fd7b1a5bd5ce4f0bb1b22432560c94c, type: 3}
+  isContainer: 0
+  isLocked: 0
+  isTan: 0
+  isOrange: 0
+  isBlue: 0
+  isShield: 0
+  isArmor: 0
+  isTreasure: 0
+  isQuiver: 0
+  isFlour: 0
+  isWarWeapon: 0
+  isSpiritualWeapon: 1
+  isMultiUseWeapon: 1
+  isHelmet: 0
+  isBreastPlate: 0
+  isGauntlet: 0
+  isHauberk: 0
+  isRing: 0
+  isPotion: 0
+  isKey: 0
+  isBomb: 0
   warAttackPower: 0
   spiritualAttackPower: 19
   warDefense: 0

--- a/Assets/Prefabs/ENEMIES/Alligator/Blue-Alligator/Alligator-Blue.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Alligator/Blue-Alligator/Alligator-Blue.vox.prefab
@@ -173,8 +173,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 4f4c8e14ad21b427fb877db76bc9e0ba, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &6798009203289821835
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -188,6 +193,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 3669482998200911138, guid: 0a4109d7fc9e24d459f4c06a2c8c1ef8, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 5742458977961993232}
 --- !u!4 &5742458977961993232 stripped
 Transform:

--- a/Assets/Prefabs/ENEMIES/Alligator/Pink-Alligator/Alligator-Pink.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Alligator/Pink-Alligator/Alligator-Pink.vox.prefab
@@ -174,8 +174,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: e205b795a72ba4cf39ec552f849cf5f0, type: 2}
   enemyBaseHP: 36
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &3882100386997635078
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -189,4 +194,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 1198239254670312718, guid: 23384a57acebc4be99fff6b3b69bfa93, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 414550355969223324}

--- a/Assets/Prefabs/ENEMIES/Alligator/Purple-Alligator/Alligator-Purple.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Alligator/Purple-Alligator/Alligator-Purple.vox.prefab
@@ -174,8 +174,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 0f13fd4469d7e45ac919163074b767b4, type: 2}
   enemyBaseHP: 39
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &8923482234782276790
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -189,4 +194,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 6233843619771494365, guid: b4c3eca7d545a4c70b39eb0e659cbea2, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 7018593090499461536}

--- a/Assets/Prefabs/ENEMIES/Ants/Blue-Ant/Ant-Blue.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Ants/Blue-Ant/Ant-Blue.vox.prefab
@@ -174,6 +174,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 1c2dc0090c4624d9199566bd7fa57bac, type: 2}
   enemyBaseHP: 25
   treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}

--- a/Assets/Prefabs/ENEMIES/Ants/Pink-Ant/Ant-Pink.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Ants/Pink-Ant/Ant-Pink.vox.prefab
@@ -169,6 +169,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 1724a75d9bd76490387689bcff443538, type: 2}
   enemyBaseHP: 29
   treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}

--- a/Assets/Prefabs/ENEMIES/Ants/Purple-Ant/Ant-Purple.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Ants/Purple-Ant/Ant-Purple.vox.prefab
@@ -194,6 +194,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 6cceceb3d39714a2d918c8b8e71feb05, type: 2}
   enemyBaseHP: 30
   treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}

--- a/Assets/Prefabs/ENEMIES/Bomb/Bomb.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Bomb/Bomb.vox.prefab
@@ -172,5 +172,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dce9b81bcb02a4c189a6628c7fe1ab0e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 8c38f04c8f78f436c915346d25378341, type: 2}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
   explosivePower: 50

--- a/Assets/Prefabs/ENEMIES/Dragons/Blue-Dragon/Dragon-Blue.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Dragons/Blue-Dragon/Dragon-Blue.vox.prefab
@@ -169,8 +169,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: c0bef7933fedb4fed8a73694a4889c13, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &6085239141124192496
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -184,6 +189,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 5335314035566461727, guid: 71acee83e2ac64f008d46c9481b461d9, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 3164561961683048931}
 --- !u!4 &3164561961683048931 stripped
 Transform:

--- a/Assets/Prefabs/ENEMIES/Dragons/Pink-Dragon/Dragon-Pink.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Dragons/Pink-Dragon/Dragon-Pink.vox.prefab
@@ -174,8 +174,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 47ab6b75c6a744843b63ab873b8b6ade, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &8393337981388568072
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -189,4 +194,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 2996252502545541546, guid: dc120157b8c8943d2bb18c9ae71aa5c8, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 4993709763740031651}

--- a/Assets/Prefabs/ENEMIES/Dragons/Purple-Dragon/Dragon-Purple.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Dragons/Purple-Dragon/Dragon-Purple.vox.prefab
@@ -169,8 +169,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: ab7d9ed564b64406891303261fb7aa2c, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &5129597762844274599
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -184,6 +189,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 4794279277654557254, guid: deae6b7c09dc84e1487e634e2f2beb8f, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 4522647214458209284}
 --- !u!4 &4522647214458209284 stripped
 Transform:

--- a/Assets/Prefabs/ENEMIES/Dwarves/No-Shield/Dwarf-Orange.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Dwarves/No-Shield/Dwarf-Orange.vox.prefab
@@ -195,8 +195,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: a5679c35fbfa74205b197d6bfae47a83, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &7904469120613319963
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -210,4 +215,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 7977670999627210375, guid: b525d35ebd2fb4eee98795cb5e005bbd, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 5123160568086255655}

--- a/Assets/Prefabs/ENEMIES/Dwarves/No-Shield/Dwarf-Tan.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Dwarves/No-Shield/Dwarf-Tan.vox.prefab
@@ -178,8 +178,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: fdbe5a9a4c6274ceaa93f751d1629116, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &481111944475583827
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -193,4 +198,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 6193374284836625802, guid: f72f59e611c7540f88963aa121360af8, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 190623478291938903}

--- a/Assets/Prefabs/ENEMIES/Dwarves/No-Shield/Dwarf-Yellow.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Dwarves/No-Shield/Dwarf-Yellow.vox.prefab
@@ -178,8 +178,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 11e8efbca106d4eef8e927c5bcea5d11, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &2020602421417707306
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -193,4 +198,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 3628909142139277534, guid: bfc346a6da04b44e9ac311ce68f1c39c, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 3536236940875045345}

--- a/Assets/Prefabs/ENEMIES/Dwarves/Shielded/Dwarf-Shield-Orange.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Dwarves/Shielded/Dwarf-Shield-Orange.vox.prefab
@@ -173,8 +173,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 4dfe14aaab7f94750ac59667e4009871, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &3079941739432346852
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -188,6 +193,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 8191541789909023615, guid: 7590855118b9947d4abfa8bf7fbf5273, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 8869659626295680211}
 --- !u!4 &8869659626295680211 stripped
 Transform:

--- a/Assets/Prefabs/ENEMIES/Dwarves/Shielded/Dwarf-Shield-Tan.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Dwarves/Shielded/Dwarf-Shield-Tan.vox.prefab
@@ -173,8 +173,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: e6d1e326aad9043849b0afc17680b015, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &3965334104964730134
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -188,6 +193,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 6001020120728717830, guid: 0b1aa02807c1f42808be75b5d30ad81d, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 7614560864968810252}
 --- !u!4 &7614560864968810252 stripped
 Transform:

--- a/Assets/Prefabs/ENEMIES/Dwarves/Shielded/Dwarf-Shield-Yellow.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Dwarves/Shielded/Dwarf-Shield-Yellow.vox.prefab
@@ -173,8 +173,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 8f316df5a835f4e8ca31d685f7683479, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &5537914757845666431
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -188,6 +193,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 2829717380952880460, guid: 74b78339c5d4a4a878cf7ccfc5e7071c, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 5593056841113463501}
 --- !u!4 &5593056841113463501 stripped
 Transform:

--- a/Assets/Prefabs/ENEMIES/EvilDoor/EvilDoorBlue.prefab
+++ b/Assets/Prefabs/ENEMIES/EvilDoor/EvilDoorBlue.prefab
@@ -123,10 +123,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: d0876cac18e6b48c09bed4273798d6e1, type: 2}
   enemyBaseHP: 50
   treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
   currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &702430640790203985
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ENEMIES/EvilDoor/EvilDoorTan.prefab
+++ b/Assets/Prefabs/ENEMIES/EvilDoor/EvilDoorTan.prefab
@@ -123,10 +123,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: af517a04e519343d5b95ed1d5e6ad7e9, type: 2}
   enemyBaseHP: 50
   treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
   currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &702430640790203985
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ENEMIES/EvilDoor/EvilDoorYellow.prefab
+++ b/Assets/Prefabs/ENEMIES/EvilDoor/EvilDoorYellow.prefab
@@ -123,10 +123,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: cc267eb22d2454c728846533a1039c8c, type: 2}
   enemyBaseHP: 50
   treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
   currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &702430640790203985
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ENEMIES/Ghouls/No-Shield/Ghoul-Grey.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Ghouls/No-Shield/Ghoul-Grey.vox.prefab
@@ -169,8 +169,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 958ed2f49bf454a6f9f2a97658c19b16, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &645510229566150208
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ENEMIES/Ghouls/No-Shield/Ghoul-Orange.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Ghouls/No-Shield/Ghoul-Orange.vox.prefab
@@ -173,8 +173,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 7a70de26662ab41439c8ea09a64b8ac4, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &1055053081247932052
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ENEMIES/Ghouls/No-Shield/Ghoul-White.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Ghouls/No-Shield/Ghoul-White.vox.prefab
@@ -178,8 +178,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 51efe1fd421714a09b44c2d25c2944e6, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &6694243569100456334
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ENEMIES/Ghouls/Shielded-Ghouls/Ghoul-Shielded-Grey.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Ghouls/Shielded-Ghouls/Ghoul-Shielded-Grey.vox.prefab
@@ -173,8 +173,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 3fec36f3c6ad14449bac4b13de12616a, type: 2}
   enemyBaseHP: 30
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &4089566642931613375
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ENEMIES/Ghouls/Shielded-Ghouls/Ghoul-Shielded-Orange.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Ghouls/Shielded-Ghouls/Ghoul-Shielded-Orange.vox.prefab
@@ -173,8 +173,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 7c85cca7a397047a3a85538f4b5bc7f8, type: 2}
   enemyBaseHP: 30
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &3353435106215911995
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ENEMIES/Ghouls/Shielded-Ghouls/Ghoul-Shielded-White.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Ghouls/Shielded-Ghouls/Ghoul-Shielded-White.vox.prefab
@@ -173,8 +173,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 63cd5ba9802444d3ca72c1f075dcdc30, type: 2}
   enemyBaseHP: 30
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &7580140999938195462
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ENEMIES/Giants/No-Shield/Giant-Orange.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Giants/No-Shield/Giant-Orange.vox.prefab
@@ -169,8 +169,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 41431041bfee14340bf503234203dc22, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &2823161796119470038
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -184,6 +189,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 6453033825085271153, guid: 18fab21f18d4543d686e67d84a674d38, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 1998420734507632744}
 --- !u!4 &1998420734507632744 stripped
 Transform:

--- a/Assets/Prefabs/ENEMIES/Giants/No-Shield/Giant-Tan.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Giants/No-Shield/Giant-Tan.vox.prefab
@@ -174,8 +174,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: c882a62a9ecc345839c711b9a7e237e0, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &848293114648447794
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -189,4 +194,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 8181331458507722103, guid: ecc1e642fb9db44bbbe5139540dfa07e, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 8223770532552805868}

--- a/Assets/Prefabs/ENEMIES/Giants/No-Shield/Giant-Yellow.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Giants/No-Shield/Giant-Yellow.vox.prefab
@@ -169,8 +169,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 982fae2213f4c40e3ab77822f7036c6a, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &5131682704248255735
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -184,6 +189,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 7021716755095671247, guid: fe466d4cfab0b4ede84b0926280cddd3, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 791790531808880581}
 --- !u!4 &791790531808880581 stripped
 Transform:

--- a/Assets/Prefabs/ENEMIES/Giants/Shielded/Giant-Shield-Orange.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Giants/Shielded/Giant-Shield-Orange.vox.prefab
@@ -173,8 +173,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: c1ae249304f0345a9bbe6b61123b2d6d, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &6362986350466585385
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -188,6 +193,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 7513751291045712066, guid: c04485d00dd4f40a8bb002386948a7cf, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 5489071197542851410}
 --- !u!4 &5489071197542851410 stripped
 Transform:

--- a/Assets/Prefabs/ENEMIES/Giants/Shielded/Giant-Shield-Tan.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Giants/Shielded/Giant-Shield-Tan.vox.prefab
@@ -173,8 +173,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 977598c02c7634ac396ba5f1f91af977, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &4525200950674181778
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -188,6 +193,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 6910574104714924688, guid: c660abdb8187a48abb068cc9cf692768, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 7894840125520262408}
 --- !u!4 &7894840125520262408 stripped
 Transform:

--- a/Assets/Prefabs/ENEMIES/Giants/Shielded/Giant-Shield-Yellow.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Giants/Shielded/Giant-Shield-Yellow.vox.prefab
@@ -173,8 +173,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: c34d27e568fd64d67b388cd5dd62db85, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &3436267241129603845
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -188,6 +193,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 1365905338622451374, guid: ad203856730074cffb7574183a7557da, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 7559549502556728439}
 --- !u!4 &7559549502556728439 stripped
 Transform:

--- a/Assets/Prefabs/ENEMIES/Minotaur/Minotaur.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Minotaur/Minotaur.vox.prefab
@@ -173,10 +173,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 5bcc88f3c6a0a45f48a851710172fb9c, type: 2}
   enemyBaseHP: 20
   treasureOfTarminPrefab: {fileID: 2620418534768044356, guid: 1c3635d810dc2454ea6d66521eb4ba23, type: 3}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
   currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &7021099410833878400
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ENEMIES/Scorpion/Blue-Scorpion/Scorpion-Blue.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Scorpion/Blue-Scorpion/Scorpion-Blue.vox.prefab
@@ -109,8 +109,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: bc4a7d5188bc846cfbc3bf93e8a5ae38, type: 2}
   enemyBaseHP: 30
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &9026296488331768102
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -124,6 +129,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 5919541258860438190, guid: b4231559ca0ab460ab871342ae9ac349, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 3757165182509153261}
 --- !u!1 &4819479006128593294
 GameObject:

--- a/Assets/Prefabs/ENEMIES/Scorpion/Pink-Scorpion/Scorpion-Pink.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Scorpion/Pink-Scorpion/Scorpion-Pink.vox.prefab
@@ -174,8 +174,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: b8728e520fec64f26ad9f65fe0c12a85, type: 2}
   enemyBaseHP: 33
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &4080614688149107622
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -189,4 +194,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 5663755838931254082, guid: 2219d6cd5d908483a94ec2719cba38a9, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 1278537345887561763}

--- a/Assets/Prefabs/ENEMIES/Scorpion/Purple-Scorpion/Scorpion-Purple.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Scorpion/Purple-Scorpion/Scorpion-Purple.vox.prefab
@@ -109,8 +109,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: e69f7ec28ed2d493b8aa3d860d570dfa, type: 2}
   enemyBaseHP: 40
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &4948592201372301996
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -124,6 +129,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   projectilePrefab: {fileID: 2013073610343398100, guid: ed90de8ad1cc3478c90b519856a9184c, type: 3}
+  secondatyProjectilePrefab: {fileID: 0}
   spawnPoint: {fileID: 3808410540674741874}
 --- !u!1 &4763729207858975761
 GameObject:

--- a/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-Cloak-Shield/Skeleton-Cloack-Shield-Grey/Skeleton-Cloacked-Shielded-Grey.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-Cloak-Shield/Skeleton-Cloack-Shield-Grey/Skeleton-Cloacked-Shielded-Grey.vox.prefab
@@ -169,12 +169,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: c91b91d6ce451435cb0deaa59e87e15b, type: 2}
   enemyBaseHP: 33
   treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
   currentEnemyHP: 0
   gridSize: 10
-  detectionDistance: 5
   detectionTimeRequired: 2
 --- !u!114 &1346927148844110373
 MonoBehaviour:

--- a/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-Cloak-Shield/Skeleton-Cloack-Shield-Orange/Skeleton-Cloacked-Shielded-Orange.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-Cloak-Shield/Skeleton-Cloack-Shield-Orange/Skeleton-Cloacked-Shielded-Orange.vox.prefab
@@ -174,12 +174,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 7787d7946079f42d3b4ccf75ebad8b6a, type: 2}
   enemyBaseHP: 35
   treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
   currentEnemyHP: 0
   gridSize: 10
-  detectionDistance: 5
   detectionTimeRequired: 2
 --- !u!114 &9134974257425558413
 MonoBehaviour:

--- a/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-Cloak-Shield/Skeleton-Cloack-Shield-White/Skeleton-Cloacked-Shielded-White.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-Cloak-Shield/Skeleton-Cloack-Shield-White/Skeleton-Cloacked-Shielded-White.vox.prefab
@@ -169,12 +169,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: bafe392f01fe54ee1aa3817c4bce7740, type: 2}
   enemyBaseHP: 28
   treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
   currentEnemyHP: 0
   gridSize: 10
-  detectionDistance: 5
   detectionTimeRequired: 2
 --- !u!114 &2288841056035684757
 MonoBehaviour:

--- a/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-Cloak/Skeleton-Cloaked-Grey/Skeleton-Cloacked-Grey.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-Cloak/Skeleton-Cloaked-Grey/Skeleton-Cloacked-Grey.vox.prefab
@@ -174,12 +174,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 249cab06d4e2b4342929f09a85b97422, type: 2}
   enemyBaseHP: 30
   treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
   currentEnemyHP: 0
   gridSize: 10
-  detectionDistance: 5
   detectionTimeRequired: 2
 --- !u!114 &7187313434675984816
 MonoBehaviour:

--- a/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-Cloak/Skeleton-Cloaked-Orange/Skeleton-Cloacked-Orange.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-Cloak/Skeleton-Cloaked-Orange/Skeleton-Cloacked-Orange.vox.prefab
@@ -169,12 +169,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 19853fd0016444c5b883548ced052ef2, type: 2}
   enemyBaseHP: 35
   treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
   currentEnemyHP: 0
   gridSize: 10
-  detectionDistance: 5
   detectionTimeRequired: 2
 --- !u!114 &7845280167543500755
 MonoBehaviour:

--- a/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-Cloak/Skeleton-Cloaked-White/Skeleton-Cloacked-White.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-Cloak/Skeleton-Cloaked-White/Skeleton-Cloacked-White.vox.prefab
@@ -174,12 +174,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 967cbeb292ef54111b78a5f530c28116, type: 2}
   enemyBaseHP: 25
   treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
   currentEnemyHP: 0
   gridSize: 10
-  detectionDistance: 5
   detectionTimeRequired: 2
 --- !u!114 &7842561734944716428
 MonoBehaviour:

--- a/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-No-Shield/Skeleton-Grey/Skeleton-Grey.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-No-Shield/Skeleton-Grey/Skeleton-Grey.vox.prefab
@@ -185,6 +185,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 485bdb5aacaea44339c3c8535933a7e7, type: 2}
   enemyBaseHP: 30
   treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}

--- a/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-No-Shield/Skeleton-Orange/Skeleton-Orange.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-No-Shield/Skeleton-Orange/Skeleton-Orange.vox.prefab
@@ -174,6 +174,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 0d1511a8b51494bbda19bb91f6205862, type: 2}
   enemyBaseHP: 40
   treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}

--- a/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-No-Shield/Skeleton-White/Skeleton-White.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-No-Shield/Skeleton-White/Skeleton-White.vox.prefab
@@ -174,6 +174,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 891c4d61a486d4191a3321e901de4a04, type: 2}
   enemyBaseHP: 20
   treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}

--- a/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-Shielded/Skeleton-Shielded-Grey.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-Shielded/Skeleton-Shielded-Grey.vox.prefab
@@ -169,6 +169,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: a24e77c608edb4498987746611983083, type: 2}
   enemyBaseHP: 35
   treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}

--- a/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-Shielded/Skeleton-Shielded-Orange.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-Shielded/Skeleton-Shielded-Orange.vox.prefab
@@ -169,6 +169,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: a9151f6ff81434e9bb62de65d0b882b0, type: 2}
   enemyBaseHP: 55
   treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}

--- a/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-Shielded/Skeleton-Shielded-White.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Skeleton/Skeleton-Shielded/Skeleton-Shielded-White.vox.prefab
@@ -195,6 +195,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 094f276eb01164ec1b2dfc5837bf9176, type: 2}
   enemyBaseHP: 25
   treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}

--- a/Assets/Prefabs/ENEMIES/Snakes/Snake-Blue.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Snakes/Snake-Blue.vox.prefab
@@ -173,8 +173,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: afb1b50cfc68c4c08b8bae3a96da2441, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &7771330199427189918
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ENEMIES/Snakes/Snake-Pink.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Snakes/Snake-Pink.vox.prefab
@@ -173,8 +173,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: a54f7524eeb2a427c8aa846be65d6536, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &7490079099662274685
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ENEMIES/Snakes/Snake-Purple.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Snakes/Snake-Purple.vox.prefab
@@ -173,8 +173,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: b105ea3723e0d4e2489218262d8d0dfb, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &1677313061075867989
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ENEMIES/Wraith/NoShield/Wraith-Grey.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Wraith/NoShield/Wraith-Grey.vox.prefab
@@ -173,8 +173,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: b1b53b688ab1b4f7084c7fbbbfebc5e7, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &4392510211571672478
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ENEMIES/Wraith/NoShield/Wraith-Orange.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Wraith/NoShield/Wraith-Orange.vox.prefab
@@ -173,8 +173,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 51f7209f67d6b4c64af1733550c84c32, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &363548675175038295
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ENEMIES/Wraith/NoShield/Wraith-White.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Wraith/NoShield/Wraith-White.vox.prefab
@@ -173,8 +173,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: ed193fc0475904150bbb6e1ce71aa026, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &5681377499749862593
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ENEMIES/Wraith/Shielded/Wraith-Shield-Grey.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Wraith/Shielded/Wraith-Shield-Grey.vox.prefab
@@ -173,8 +173,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 22391578e457d40e287c7e6a3759c699, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &1410565223322434590
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ENEMIES/Wraith/Shielded/Wraith-Shield-Orange.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Wraith/Shielded/Wraith-Shield-Orange.vox.prefab
@@ -178,8 +178,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: e99343e6f533c499d8a57010168810c3, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &4846107439803693376
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ENEMIES/Wraith/Shielded/Wraith-Shield-White.vox.prefab
+++ b/Assets/Prefabs/ENEMIES/Wraith/Shielded/Wraith-Shield-White.vox.prefab
@@ -178,8 +178,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3ec14790ff624dd49ef31bddd3f8160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyMapping: {fileID: 11400000, guid: 2c9ef2f3e5b7b4227a1597ad10371031, type: 2}
   enemyBaseHP: 20
+  treasureOfTarminPrefab: {fileID: 0}
   smokePrefab: {fileID: 2719968490211820838, guid: a329a0e665abc466fabe9beb48167f78, type: 3}
+  currentEnemyHP: 0
+  gridSize: 10
+  detectionTimeRequired: 2
 --- !u!114 &2074988656464343064
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/MAZESETS/Maze14.prefab
+++ b/Assets/Prefabs/MAZESETS/Maze14.prefab
@@ -33,10 +33,10 @@ Transform:
   - {fileID: 8528485706548462059}
   - {fileID: 7545884383621608309}
   - {fileID: 3435038188744549046}
-  - {fileID: 2769481819129397840}
   - {fileID: 106757747214422056}
   - {fileID: 6517297707258713561}
   - {fileID: 3536915410370370480}
+  - {fileID: 8903024295387178239}
   - {fileID: 4262886400547745472}
   - {fileID: 1210347853968420478}
   - {fileID: 7329305668642164877}
@@ -57,13 +57,13 @@ Transform:
   - {fileID: 5893838741362739693}
   - {fileID: 5582413034186896349}
   - {fileID: 810368778780399178}
+  - {fileID: 5919125871135656420}
   - {fileID: 7228934080617770888}
   - {fileID: 6593584825917570993}
   - {fileID: 8455013545126395123}
   - {fileID: 3493216028053924603}
   - {fileID: 105296102793863628}
   - {fileID: 8148409807782226124}
-  - {fileID: 953046015246554124}
   - {fileID: 2766004475481427958}
   - {fileID: 5902225661751842598}
   - {fileID: 117000123499532061}
@@ -334,6 +334,80 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
   m_PrefabInstance: {fileID: 373118975582342653}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &647168448411199721
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2606708839726506786}
+    m_Modifications:
+    - target: {fileID: 3710858880978090449, guid: c25526316abad42e8990e9e59926780e, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6310961315995585655, guid: c25526316abad42e8990e9e59926780e, type: 3}
+      propertyPath: m_Name
+      value: NormalWallLight (08)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6310961315995585655, guid: c25526316abad42e8990e9e59926780e, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6310961315995585655, guid: c25526316abad42e8990e9e59926780e, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 47.480003
+      objectReference: {fileID: 0}
+    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 49.95
+      objectReference: {fileID: 0}
+    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c25526316abad42e8990e9e59926780e, type: 3}
+--- !u!4 &8903024295387178239 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
+  m_PrefabInstance: {fileID: 647168448411199721}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &708620661277373592
 PrefabInstance:
@@ -1809,80 +1883,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3588486699552315495, guid: 9439f73675387464aa4bcb2b59c76eae, type: 3}
   m_PrefabInstance: {fileID: 5443126369983467000}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &6132209589615464006
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2606708839726506786}
-    m_Modifications:
-    - target: {fileID: 3710858880978090449, guid: c25526316abad42e8990e9e59926780e, type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6310961315995585655, guid: c25526316abad42e8990e9e59926780e, type: 3}
-      propertyPath: m_Name
-      value: NormalWallLight (04)
-      objectReference: {fileID: 0}
-    - target: {fileID: 6310961315995585655, guid: c25526316abad42e8990e9e59926780e, type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6310961315995585655, guid: c25526316abad42e8990e9e59926780e, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 47.54
-      objectReference: {fileID: 0}
-    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 49.91
-      objectReference: {fileID: 0}
-    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c25526316abad42e8990e9e59926780e, type: 3}
---- !u!4 &2769481819129397840 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
-  m_PrefabInstance: {fileID: 6132209589615464006}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6287022437823558702
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2058,92 +2058,6 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 9146451320418603050, guid: d2cdd78b4bd63478d93ac6b1aae16019, type: 3}
   m_PrefabInstance: {fileID: 6380592894226603996}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &6588781556058259950
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2606708839726506786}
-    m_Modifications:
-    - target: {fileID: 4197273816877654761, guid: 63b52acfab5e346358c43b83bdab6505, type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4963724831256052674, guid: 63b52acfab5e346358c43b83bdab6505, type: 3}
-      propertyPath: m_Name
-      value: SecretDoorWallDark (3)
-      objectReference: {fileID: 0}
-    - target: {fileID: 4963724831256052674, guid: 63b52acfab5e346358c43b83bdab6505, type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4963724831256052674, guid: 63b52acfab5e346358c43b83bdab6505, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6217759866243569122, guid: 63b52acfab5e346358c43b83bdab6505, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 47.530006
-      objectReference: {fileID: 0}
-    - target: {fileID: 6217759866243569122, guid: 63b52acfab5e346358c43b83bdab6505, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6217759866243569122, guid: 63b52acfab5e346358c43b83bdab6505, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 38.38998
-      objectReference: {fileID: 0}
-    - target: {fileID: 6217759866243569122, guid: 63b52acfab5e346358c43b83bdab6505, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 6217759866243569122, guid: 63b52acfab5e346358c43b83bdab6505, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6217759866243569122, guid: 63b52acfab5e346358c43b83bdab6505, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 6217759866243569122, guid: 63b52acfab5e346358c43b83bdab6505, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6217759866243569122, guid: 63b52acfab5e346358c43b83bdab6505, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6217759866243569122, guid: 63b52acfab5e346358c43b83bdab6505, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: 6217759866243569122, guid: 63b52acfab5e346358c43b83bdab6505, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7824063315176886996, guid: 63b52acfab5e346358c43b83bdab6505, type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8041285438214123298, guid: 63b52acfab5e346358c43b83bdab6505, type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8147075887194249523, guid: 63b52acfab5e346358c43b83bdab6505, type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 63b52acfab5e346358c43b83bdab6505, type: 3}
---- !u!4 &953046015246554124 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6217759866243569122, guid: 63b52acfab5e346358c43b83bdab6505, type: 3}
-  m_PrefabInstance: {fileID: 6588781556058259950}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6691614723808390816
 PrefabInstance:
@@ -2514,6 +2428,80 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 8320067345508355094, guid: c25526316abad42e8990e9e59926780e, type: 3}
   m_PrefabInstance: {fileID: 7186291307804615272}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7199048235835068803
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2606708839726506786}
+    m_Modifications:
+    - target: {fileID: 3588486699552315495, guid: 9439f73675387464aa4bcb2b59c76eae, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 52.58001
+      objectReference: {fileID: 0}
+    - target: {fileID: 3588486699552315495, guid: 9439f73675387464aa4bcb2b59c76eae, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3588486699552315495, guid: 9439f73675387464aa4bcb2b59c76eae, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 30.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3588486699552315495, guid: 9439f73675387464aa4bcb2b59c76eae, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 3588486699552315495, guid: 9439f73675387464aa4bcb2b59c76eae, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3588486699552315495, guid: 9439f73675387464aa4bcb2b59c76eae, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 3588486699552315495, guid: 9439f73675387464aa4bcb2b59c76eae, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3588486699552315495, guid: 9439f73675387464aa4bcb2b59c76eae, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3588486699552315495, guid: 9439f73675387464aa4bcb2b59c76eae, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 3588486699552315495, guid: 9439f73675387464aa4bcb2b59c76eae, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4959227729693817793, guid: 9439f73675387464aa4bcb2b59c76eae, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593811593999615231, guid: 9439f73675387464aa4bcb2b59c76eae, type: 3}
+      propertyPath: m_Name
+      value: NormalWallDark (12)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593811593999615231, guid: 9439f73675387464aa4bcb2b59c76eae, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593811593999615231, guid: 9439f73675387464aa4bcb2b59c76eae, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9439f73675387464aa4bcb2b59c76eae, type: 3}
+--- !u!4 &5919125871135656420 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3588486699552315495, guid: 9439f73675387464aa4bcb2b59c76eae, type: 3}
+  m_PrefabInstance: {fileID: 7199048235835068803}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7364386906357514009
 PrefabInstance:
@@ -3017,7 +3005,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9146451320418603050, guid: d2cdd78b4bd63478d93ac6b1aae16019, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0.08
       objectReference: {fileID: 0}
     - target: {fileID: 9146451320418603050, guid: d2cdd78b4bd63478d93ac6b1aae16019, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Large/Blue/Fireball-Large-Blue.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Large/Blue/Fireball-Large-Blue.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 149a90aeb91c640b9bb0ea9617af8abf, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Large/Grey/Fireball-Large-Grey.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Large/Grey/Fireball-Large-Grey.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 57209d6e0537e4017986e44fc161a144, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Large/Pink/Fireball-Large-Pink.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Large/Pink/Fireball-Large-Pink.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 5d3f12241b4a042d2be8555649b31d6d, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Large/Purple/Fireball-Large-Purple.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Large/Purple/Fireball-Large-Purple.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 4336a7bbe7a674f8e9e98592fa548460, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Large/Red/Fireball-Large-Red.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Large/Red/Fireball-Large-Red.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 4898c16e2fb144cea8885b0f889da2d5, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Large/White/Fireball-Large-White.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Large/White/Fireball-Large-White.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 8684075f5fb3e416c9c1673bde81f38f, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Small/Blue/Fireball-Small-Blue.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Small/Blue/Fireball-Small-Blue.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 241d86640b0e1429e8b9bdf2774756e1, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Small/Grey/Fireball-Small-Grey.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Small/Grey/Fireball-Small-Grey.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 7d36d8d0ffc1644b8911e10bcd0bdfe2, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Small/Pink/Fireball-Small-Pink.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Small/Pink/Fireball-Small-Pink.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: e12265adb13ae450c966a5ea8c0ba0a4, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Small/Purple/Fireball-Small-Purple.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Small/Purple/Fireball-Small-Purple.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 8aaf88ac5b86c4a15a9a3ca3161c02fe, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Small/Red/Fireball-Small-Red.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Small/Red/Fireball-Small-Red.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 84e50c0fb21ff4acf8162a2bbf8b7ba2, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Small/White/Fireball-Small-White.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Fireballs-Small/White/Fireball-Small-White.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 592105dbf9f794255a1163255809796c, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Large/Blue/Lightning-Large-Blue.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Large/Blue/Lightning-Large-Blue.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 9e0598a37468944869530caf0a1eb77a, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Large/Grey/Lightning-Large-Grey.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Large/Grey/Lightning-Large-Grey.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: b93266d3dd44340278487980ab87d620, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Large/Pink/Lightning-Large-Pink.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Large/Pink/Lightning-Large-Pink.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 4ff68d519633c4d90aec053a3b0e7763, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Large/Purple/Lightning-Large-Purple.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Large/Purple/Lightning-Large-Purple.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 622bfcec34ed24c798f96f8dc4945c2f, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Large/Red/Lightning-Large-Red.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Large/Red/Lightning-Large-Red.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 65ea93400031148d28193e28df649b04, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Large/White/Lightning-Large-White.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Large/White/Lightning-Large-White.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 6e0f7d40fefbc4c28a6ff8755dd30bcf, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Small/Blue/Lightning-Small-Blue.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Small/Blue/Lightning-Small-Blue.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: ac27f16e9849e412d93f0178cc5298b2, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Small/Grey/Lightning-Small-Grey.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Small/Grey/Lightning-Small-Grey.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 4806bef5f34324c3a91fda8749be25f7, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Small/Pink/Lightning-Small-Pink.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Small/Pink/Lightning-Small-Pink.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 1ee34b7d6c8cd446eac5f2a0d5035f7c, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Small/Purple/Lightning-Small-Purple.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Small/Purple/Lightning-Small-Purple.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 84667aa45f4a04c7b9e8d0580cdcc0d1, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Small/Red/Lightning-Small-Red.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Small/Red/Lightning-Small-Red.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: bad4d1b6c38d846ecbae72d868db7801, type: 2}

--- a/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Small/White/Lightning-Small-White.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/Spiritual-Weapons/Ligthning-Small/White/Lightning-Small-White.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: f7b2875edee294f2a99f9d8cfbe8c072, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Axes/Blue/Axe-Blue.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Axes/Blue/Axe-Blue.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 35b832ec35ddb4f37b5573828c3c6f12, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Axes/Grey/Axe-Grey.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Axes/Grey/Axe-Grey.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 5170837274f8148958153e80ccf64c7a, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Axes/Orange/Axe-Orange.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Axes/Orange/Axe-Orange.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: d3c4c89efc1e34a3380aaa08e0c8b152, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Axes/Tan/Axe-Tan.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Axes/Tan/Axe-Tan.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: b8c4f8d7655ab4eefa6b6be8cdfa1f8c, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Axes/White/Axe-White.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Axes/White/Axe-White.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 3ccd3b00f315943b290cc4af55c95c0e, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Axes/Yellow/Axe-Yellow.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Axes/Yellow/Axe-Yellow.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 598814720529a4bb59ff15443f78772b, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Darts/Blue/Dart-Blue.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Darts/Blue/Dart-Blue.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: a100245c7bf644f3abf6a02e5c2fb673, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Darts/Grey/Dart-Grey.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Darts/Grey/Dart-Grey.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 6c8ce705b4baf43aca037b5dc8983638, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Darts/Orange/Dart-Orange.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Darts/Orange/Dart-Orange.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 509d4f3ff168a4569873b46f784b3e90, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Darts/Tan/Dart-Tan.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Darts/Tan/Dart-Tan.vox.prefab
@@ -174,3 +174,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 9716e7732e5064ffc86b83f75566c493, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Darts/White/Dart-White.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Darts/White/Dart-White.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 890ad33b1bf4742848a32f43d76f4c29, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Darts/Yellow/Dart-Yellow.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Darts/Yellow/Dart-Yellow.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: f28cf2b27424e4487850efad9b1bff85, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Knives/Blue/Knife-Blue.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Knives/Blue/Knife-Blue.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: f01a3b3e8db524a8a9657dfd5c9eb681, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Knives/Grey/Knife-Grey.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Knives/Grey/Knife-Grey.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 46220370c4d60420ba53aa7055eb1b06, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Knives/Orange/Knife-Orange.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Knives/Orange/Knife-Orange.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 47e39a578954c431e959030be7fc14f4, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Knives/Tan/Knife-Tan.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Knives/Tan/Knife-Tan.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 8a0cc34827175472aa07cd227a938895, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Knives/White/Knife-White.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Knives/White/Knife-White.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 5497b104982b941ebad66b15192754c0, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Knives/Yellow/Knife-Yellow.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Knives/Yellow/Knife-Yellow.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 7cecd8caa7c7c4704b8a8f157bbb6af4, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Spears/Blue/Spear-Blue.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Spears/Blue/Spear-Blue.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: e470ba1db1d754be38f4689df2cb00d4, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Spears/Grey/Spear-Grey.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Spears/Grey/Spear-Grey.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: d03c8b311ab22498abdd341787576963, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Spears/Orange/Spear-Orange.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Spears/Orange/Spear-Orange.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: cce32e9ed28244d95958a24ccb4a6eab, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Spears/Tan/Spear-Tan.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Spears/Tan/Spear-Tan.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: 8bb38882c555b452e826f46ad3bdd9f8, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Spears/White/Spear-White.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Spears/White/Spear-White.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: f278dbef26f764ac4a854527d0bedf60, type: 2}

--- a/Assets/Prefabs/WEAPONS/War-Weapons/Spears/Yellow/Spear-Yellow.vox.prefab
+++ b/Assets/Prefabs/WEAPONS/War-Weapons/Spears/Yellow/Spear-Yellow.vox.prefab
@@ -158,3 +158,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f35b0fd15cdb4b6ca799b2c32f8541b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemMapping: {fileID: 11400000, guid: ddb63fe4808e941eaaede87485695d6c, type: 2}

--- a/Assets/Scripts/Bomb.cs
+++ b/Assets/Scripts/Bomb.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class Bomb : MonoBehaviour
 {
+    [SerializeField] private EnemyMapping enemyMapping;  // assign via inspector
     [SerializeField] private GameObject smokePrefab;
     [HideInInspector] public int explosivePower = 50;  //So other classes can modify but not the editor
     PlayerGridMovement playerGridMovement;

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -1,22 +1,24 @@
-//sing Unity.Mathematics;
-using System.Collections;
+using Unity.Mathematics;
+using System;
 using UnityEngine;
 
 public class Enemy : MonoBehaviour
 {
-    //[SerializeField] private string enemyName = "WhiteSkeleton";
-    [SerializeField] private int enemyBaseHP = 50;
+    [SerializeField] private EnemyMapping enemyMapping;  // assigned via inspector
     [SerializeField] private GameObject treasureOfTarminPrefab;
     GameManager gameManager;
     PlayerGridMovement playerGridMovement;
     Player player;
     PlayerAmbushDetection playerAmbushDetection;
-    //PlayerShootingSpawner playerShootingSpawner;
+    FloorManager floorManager;
+    MazeBlock mazeBlock;
+    private string currentFloorColor;
+    private int enemyBaseHP;
     public GameObject smokePrefab; // Assign SmokePrefab in the Inspector
     public int currentEnemyHP;
     private float maxInteractionDistance = 5f;
     public float gridSize = 10.0f; //Size of each grid step
-
+    
     // Detection / Ambush
     [Header("Ambush Settings")]
     //public float detectionDistance = 10f;     // How far the enemy can see forward
@@ -32,16 +34,42 @@ public class Enemy : MonoBehaviour
         playerGridMovement = GameObject.Find("Player").GetComponent<PlayerGridMovement>();
         player = GameObject.Find("Player").GetComponent<Player>();
         playerAmbushDetection = GameObject.Find("Player").GetComponent<PlayerAmbushDetection>();
-        //playerShootingSpawner = GameObject.Find("PlayerShootingSpawner").GetComponent<PlayerShootingSpawner>();
-
-        currentEnemyHP = Random.Range(0,15) + enemyBaseHP;
+        floorManager = GameObject.Find("FloorManager").GetComponent<FloorManager>();
+        GetFloorType();
         gameManager.UpdateEnemyHP(currentEnemyHP);
+        SetEnemyHP();
     }
 
     // Update is called once per frame
     void Update()
     {}
 
+    private void GetFloorType() {
+        //Tan, Blue, or Green
+        currentFloorColor = gameManager.currentMazeBlock.colorType.ToString();
+    }
+
+    private void SetEnemyHP() {
+        //FLOOR BASED HP
+        if (currentFloorColor == "Green") { //WAR FLOOR
+            float baseHP = enemyMapping.baseWarHP;
+            float bonus = UnityEngine.Random.Range(baseHP * 0.05f, baseHP * 0.25f);
+            currentEnemyHP = Mathf.RoundToInt(baseHP + bonus);
+            Debug.Log("Set Enemy " + gameObject.name + " HP of " + currentEnemyHP);
+        } else if (currentFloorColor == "Blue") { //SPIRITUAL FLOOR
+            float baseHP = enemyMapping.baseSpiritualHP;
+            float bonus = UnityEngine.Random.Range(baseHP * 0.05f, baseHP * 0.25f);
+            currentEnemyHP = Mathf.RoundToInt(baseHP + bonus);
+            Debug.Log("Set Enemy " + gameObject.name + " HP of " + currentEnemyHP);
+        }  else if (currentFloorColor == "Tan") { //MIXED FLOOR (USES HIGHER HP)
+            float baseSpiritualHP = enemyMapping.baseSpiritualHP;
+            float baseWarHP = enemyMapping.baseWarHP;
+            float baseHP = (baseSpiritualHP > baseWarHP) ? baseSpiritualHP : baseWarHP;
+            float bonus = UnityEngine.Random.Range(baseHP * 0.05f, baseHP * 0.25f);
+            currentEnemyHP = Mathf.RoundToInt(baseHP + bonus);
+            Debug.Log("Set Enemy " + gameObject.name + " HP of " + currentEnemyHP);
+        }
+    }
 
     public void TakeDamage(int damage) {
         currentEnemyHP -= damage;

--- a/Assets/Scripts/FloorManager.cs
+++ b/Assets/Scripts/FloorManager.cs
@@ -263,6 +263,8 @@ public class FloorManager : MonoBehaviour
         Debug.Log("CurrentNeighbourRight is " + currentNeighbourRight + " At " + (currentNeighbourRight?.gridCoordinate.ToString() ?? "null"));
         Debug.Log("CurrentNeighbourBelowLeft is " + currentNeighbourBelowLeft + " At " + (currentNeighbourBelowLeft?.gridCoordinate.ToString() ?? "null"));
         Debug.Log("CurrentNeighbourBelowRight is " + currentNeighbourBelowRight + " At " + (currentNeighbourBelowRight?.gridCoordinate.ToString() ?? "null"));
+    
+        gameManager.UpdateCurrentMazeBlockType(mazeGenerator.currentPlayerBlock);
     }
 
 
@@ -584,6 +586,7 @@ public class FloorManager : MonoBehaviour
         
         ReserveFixedLadderPositions();
 
+        gameManager.UpdateCurrentMazeBlockType(currentBlock);
 
         // (2) Determine how many items/enemies to spawn and which prefab arrays to use based on blockColor.
         int itemCount, enemyCount, quiverCount, flourCount, defensiveItemsCount, weaponsCount;

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -14,6 +14,8 @@ public class GameManager : MonoBehaviour
     [SerializeField] public bool isFighting = false;
     [SerializeField] public bool isPlayersTurn = true;
     [SerializeField] public bool isEnemysTurn = false;
+    public MazeBlock currentMazeBlock;
+    public string currentMazeBlockColor;
     public bool isFreeAttackPhase = false;
     public bool isPassiveFight = false;
     public bool ambushInProgress = false;
@@ -70,6 +72,11 @@ public class GameManager : MonoBehaviour
         viewSwitcher.SwitchToGameView();
     }
 
+
+    public void UpdateCurrentMazeBlockType(MazeBlock currentPlayerMazeBlock) {
+        currentMazeBlock = currentPlayerMazeBlock;
+        Debug.Log("GameManager, Current MazeBlock is" + currentMazeBlock);
+    }
 
     void Update()
     {}

--- a/Assets/Scripts/ItemMapping.cs
+++ b/Assets/Scripts/ItemMapping.cs
@@ -19,6 +19,7 @@ public class ItemMapping : ScriptableObject
     public bool isFlour;
     public bool isWarWeapon;
     public bool isSpiritualWeapon;
+    public bool isMultiUseWeapon;
     public bool isHelmet;
     public bool isBreastPlate;
     public bool isGauntlet;

--- a/Assets/Scripts/PlayerShootingSpawner.cs
+++ b/Assets/Scripts/PlayerShootingSpawner.cs
@@ -94,6 +94,7 @@ public class PlayerShootingSpawner : MonoBehaviour
             ItemPositioning itemPositioning = projectile.GetComponent<ItemPositioning>();
             if (itemPositioning != null) Destroy(itemPositioning);
 
+            
             Projectile proj = projectile.GetComponent<Projectile>();
             if (proj != null)
             {
@@ -102,7 +103,7 @@ public class PlayerShootingSpawner : MonoBehaviour
             Debug.Log("Shot " + currentItemMapping.ammo);
 
             StartCoroutine(ResetPlayerAttackFlag());
-            ConsumeItem();
+            //ConsumeItem();
 
 
             //BRIBE MECHANIC
@@ -123,6 +124,24 @@ public class PlayerShootingSpawner : MonoBehaviour
         }
     }
 
+    public int MultiUseWeaponFired() {
+        ItemMapping currentItemMapping = FigureOutCurrentItemMapping();
+        if (currentItemMapping.isMultiUseWeapon) {
+            Debug.Log("Using MULTIUSE WEAPON");
+            float damageWar = currentItemMapping.warAttackPower;
+            float damageSpiritual = currentItemMapping.spiritualAttackPower;
+            float damage = (damageWar > damageSpiritual) ? damageWar : damageSpiritual;
+            float bonusDamage = UnityEngine.Random.Range(damage * 0.05f, damage * 0.25f);
+            damage = damage + bonusDamage;
+            int multiUseAttackDamage = Mathf.RoundToInt(damage);
+            Debug.Log("Damage to Enemy with Multiuse is " + multiUseAttackDamage);
+            //gameManager.activeEnemy.TakeDamage(attackDamage);
+            //enemy.TakeDamage(attackDamage);
+            return multiUseAttackDamage;
+        } else {
+            return 0; //No Multiuse weapon in hand
+        }
+    }
 
     IEnumerator ResetPlayerAttackFlag()
     {
@@ -137,7 +156,7 @@ public class PlayerShootingSpawner : MonoBehaviour
         gameManager.SetPlayerMessage("Successfully Bribed!");
     }
 
-    private void ConsumeItem() {
+    public void ConsumeItem() {
         if (inventoryManager.rightHandSlot.texture.name.Contains("Bow") || 
             inventoryManager.rightHandSlot.texture.name.Contains("Crossbow") ||
             inventoryManager.rightHandSlot.texture.name.Contains("Spell") || 

--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -64,7 +64,6 @@ public class Projectile : MonoBehaviour
                         enemy.TakeDamage(usingMultiUseWeaponDamage);
                     }
                 }
-                Destroy(gameObject);
             }
             else if (other.CompareTag("Player"))
             {
@@ -73,8 +72,8 @@ public class Projectile : MonoBehaviour
                 {
                     player.ModifyPhysicalStrength(-attackDamage);
                 }
-                Destroy(gameObject);
             }
+        Destroy(gameObject);
         }
     }
 }

--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -2,11 +2,19 @@ using UnityEngine;
 
 public class Projectile : MonoBehaviour
 {
+    [SerializeField] ItemMapping itemMapping;
     private float projectileSpeed = 12f; // Speed of the projectile
-    private int damage = 10;
+    private float damage;
     private int amount = -10;
     private Vector3 direction;
+    ItemMapping currentItemMapping; 
+    PlayerShootingSpawner playerShootingSpawner;
 
+
+    void Start()
+    {
+        playerShootingSpawner = GameObject.Find("PlayerShootingSpawner").GetComponent<PlayerShootingSpawner>();
+    }
     // Called after instantiation to initialize the projectile
     public void Initialize(Vector3 shooterPosition, Vector3 targetPosition)
     {
@@ -26,6 +34,15 @@ public class Projectile : MonoBehaviour
 
     private void OnTriggerEnter(Collider other)
     {
+        //Check which attack is stronger War or Spiritual, use higher, apply a bonus between 5 and 25% and convert back to int
+        float damageWar = itemMapping.warAttackPower;
+        float damageSpiritual = itemMapping.spiritualAttackPower;
+        damage = (damageWar > damageSpiritual) ? damageWar : damageSpiritual;
+        float bonusDamage = Random.Range(damage * 0.05f, damage * 0.25f);
+        damage = damage + bonusDamage;
+        int attackDamage = Mathf.RoundToInt(damage);
+        Debug.Log("Damage is " + attackDamage);
+
         if (other.CompareTag("Enemy") || other.CompareTag("Player"))
         {
             Debug.Log($"HIT {other.tag}");
@@ -35,19 +52,29 @@ public class Projectile : MonoBehaviour
                 Enemy enemy = other.GetComponent<Enemy>();
                 if (enemy != null)
                 {
-                    enemy.TakeDamage(damage);
+                    //The MULTIUSE WEAPON DAMAGE IS NOW CALCULATED ON PLAYER SHOOTING SPAWNER, OTHER WEAPONS USE THE CALCULATION ABOVE WITHIN THIS SCRIPT
+                    int usingMultiUseWeaponDamage = playerShootingSpawner.MultiUseWeaponFired();
+                    Debug.Log("usingMultiUseWeaponDamage is " + usingMultiUseWeaponDamage);
+                    if (usingMultiUseWeaponDamage == 0) {
+                        Debug.Log("Using SingleUse Weapon");
+                        enemy.TakeDamage(attackDamage);
+                        playerShootingSpawner.ConsumeItem(); //MOVED THIS HERE TO AVOID NULL REFERENCE AFTER THE ITEM IS NO LONGER IN HAND
+                    } else {
+                        Debug.Log("Using MultiUse Weapon");
+                        enemy.TakeDamage(usingMultiUseWeaponDamage);
+                    }
                 }
+                Destroy(gameObject);
             }
             else if (other.CompareTag("Player"))
             {
                 Player player = other.GetComponent<Player>();
                 if (player != null)
                 {
-                    player.ModifyPhysicalStrength(amount);
+                    player.ModifyPhysicalStrength(-attackDamage);
                 }
+                Destroy(gameObject);
             }
-
-            Destroy(gameObject);
         }
     }
 }


### PR DESCRIPTION
Enemies and Player now attack with the attack power that is in the weapon ItemMapping.   A simple formula is used at this point to add a random bonus.  

I find currently weapons do too much damage but this is in part because defense is not yet implemented.

Also, there is no relation to floor bonuses from enemy attacks.

These values will be tweaked but for now the mechanics work.  This includes logic to determine if the weapon is singleuse or multiuse as the ammo of mulituse attack power is different than the single weapon it shoots.

Also found a wrong wall in Maze14 which is fixed too.